### PR TITLE
mistake discovered in context setup

### DIFF
--- a/ox/lib/Ox_MongoSourceSSL.php
+++ b/ox/lib/Ox_MongoSourceSSL.php
@@ -90,7 +90,7 @@ class Ox_MongoSourceSSL extends Ox_MongoSource
                 }
 
                 /* Certificate Authority the remote server certificate must be signed by */
-                $context_information["cafile"] = $this->_config['private_key_file'];
+                $context_information['ssl']['cafile'] = $this->_config['private_key_file'];
                 $ctx = stream_context_create($context_information);
 
                 $this->_connection = new MongoClient($host, array('ssl'=>true), $ctx);


### PR DESCRIPTION
Certificate file was set at the incorrect level in the context configuration. This has been fixed.