### PR TITLE
Declare static method as static

### DIFF
--- a/ox/lib/Ox_Hook.php
+++ b/ox/lib/Ox_Hook.php
@@ -67,7 +67,7 @@ class Ox_Hook
      * </code>
      * @param string $construct
      */
-    public function initializeModuleConstruct($construct)
+    public static function initializeModuleConstruct($construct)
     {
         require_once(DIR_CONSTRUCT. $construct . DIRECTORY_SEPARATOR . 'hook.php');
         $hookObjectName = $construct . 'Hook';

--- a/ox/lib/asset_managers/Ox_LocalAsset.php
+++ b/ox/lib/asset_managers/Ox_LocalAsset.php
@@ -51,9 +51,9 @@ class LocalAsset extends Ox_Asset
      * @param $fieldName string
      * @return array|bool|null (the uploaded asset record)
      */
-    public function save($file_info,$fieldName='file')
+    public function save($file_info, $fieldName = 'file', array $extra_fields = array())
     {
-        $doc = parent::save($file_info,$fieldName);
+        $doc = parent::save($file_info, $fieldName, $extra_fields);
         if(empty($doc)) {
             return false;
         }


### PR DESCRIPTION
This fixes warnings thrown by PHP 5.5