### PR TITLE
Self-signed certs version of SSL code.

### DIFF
--- a/ox/lib/Ox_MongoSource.php
+++ b/ox/lib/Ox_MongoSource.php
@@ -40,13 +40,13 @@ class Ox_MongoSource
      * The configure we use to setup the connection
      * @var array
      */
-    private $_config;
+    protected $_config;
 
     /**
      * Connect to Mongo
      * @var Mongo
      */
-    private $_connection;
+    protected $_connection;
 
     /**
      * Database Instance
@@ -54,7 +54,7 @@ class Ox_MongoSource
      * @var MongoDB
      * @access protected
      */
-    private $_db = false;
+    protected $_db = false;
 
     /**
      * Mongo Driver Version
@@ -62,7 +62,7 @@ class Ox_MongoSource
      * @var string
      * @access protected
      */
-    private $_driverVersion = Mongo::VERSION;
+    protected $_driverVersion = Mongo::VERSION;
 
     /**
      * List of created collections.
@@ -70,7 +70,7 @@ class Ox_MongoSource
      * Need to maintain collection state.
      * @var array
      */
-    private $_collectionCache = array();
+    protected $_collectionCache = array();
 
     /**
      * Create connection URI.

--- a/ox/lib/Ox_MongoSourceSSL.php
+++ b/ox/lib/Ox_MongoSourceSSL.php
@@ -69,32 +69,31 @@ class Ox_MongoSourceSSL extends Ox_MongoSource
             if (isset($this->_config['replicaset']) && count($this->_config['replicaset']) === 2) {
                 $this->_connection = new Mongo($this->_config['replicaset']['host'], $this->_config['replicaset']['options']);
             } else if ($this->_driverVersion >= '1.3.0') {
-                $context_information = array(
-                    "ssl" => array(
+                //$context_information = array(
+                    //"ssl" => array(
                         /* Disable self signed certificates */
-                        "allow_self_signed" => false,
+                        //"allow_self_signed" => false,
 
                         /* Verify the peer certificate against our provided Certificate Authority root certificate */
-                        "verify_peer"       => true, /* Default to false pre PHP 5.6 */
+                        //"verify_peer"       => true, /* Default to false pre PHP 5.6 */
 
                         /* Verify the peer name (e.g. hostname validation) */
                         /* Will use the hostname used to connec to the node */
-                        "verify_peer_name"  => true,
+                        //"verify_peer_name"  => true,
 
                     /* Verify the server certificate has not expired */
-                        "verify_expiry"     => true, /* Only available in the MongoDB PHP Driver */
-                ));
-                if(empty($this->_config['private_key_file']) || !file_exists($this->_config['private_key_file'])) {
+                        //"verify_expiry"     => true, /* Only available in the MongoDB PHP Driver */
+                //));
+                /*if(empty($this->_config['private_key_file']) || !file_exists($this->_config['private_key_file'])) {
                     Ox_Logger::logError("SSL certificate file " . $this->_config['private_key_file'] . " does not exist.");
                     throw new Ox_MongoSourceException("SSL certificate file " . $this->_config['private_key_file'] . " does not exist.");
                     return false;
                 }
 
                 /* Certificate Authority the remote server certificate must be signed by */
-                $context_information['ssl']['cafile'] = $this->_config['private_key_file'];
-                $ctx = stream_context_create($context_information);
-
-                $this->_connection = new MongoClient($host, array('ssl'=>true), array('context'=> $ctx));
+                //$context_information['ssl']['cafile'] = $this->_config['private_key_file'];
+                //$ctx = stream_context_create($context_information);
+                $this->_connection = new MongoClient($host, array('ssl'=>true));//, array('context'=> $ctx));
             } else if ($this->_driverVersion >= '1.2.0') {
                 //TODO: Write support for this driver version.
                 Ox_Logger::logError("MongoDB SSL is not supported on this version of the MongoDB driver");


### PR DESCRIPTION
Ox_MongoSource updated to use protected instead of private variables so that Ox_MongoSourceSSL properly inherits these members. Some code in Ox_MongoSourceSSL has been temporarily commented out until it can be properly tested.